### PR TITLE
fix: resolve API pages 500 errors and add /menu redirect

### DIFF
--- a/backend/src/user/pages.controller.ts
+++ b/backend/src/user/pages.controller.ts
@@ -1,12 +1,24 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Req } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { SiteSetting } from '../admin/site-setting.entity';
+import { Request } from 'express';
 
 @Controller('pages')
 export class PagesController {
   constructor(@InjectRepository(SiteSetting) private repo: Repository<SiteSetting>) {}
 
-  @Get('about')  async about()  { return (await this.repo.findOne({ where: { key: 'about' } }))?.value ?? ''; }
-  @Get('infoes') async infoes() { return (await this.repo.findOne({ where: { key: 'infoes' } }))?.value ?? ''; }
+  @Get('about')  
+  async about(@Req() req: Request) { 
+    const tenantId = (req as any)?.tenant?.id;
+    if (!tenantId) return '';
+    return (await this.repo.findOne({ where: { key: 'about', tenantId } }))?.value ?? ''; 
+  }
+  
+  @Get('infoes') 
+  async infoes(@Req() req: Request) { 
+    const tenantId = (req as any)?.tenant?.id;
+    if (!tenantId) return '';
+    return (await this.repo.findOne({ where: { key: 'infoes', tenantId } }))?.value ?? ''; 
+  }
 }

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -213,6 +213,10 @@ export function middleware(req: NextRequest) {
     return redirect('/', req);
   }
 
+  if (path === '/menu') {
+    return redirect('/user/menu', req);
+  }
+
   return response ?? NextResponse.next();
 }
 


### PR DESCRIPTION
# fix: resolve API pages 500 errors and add /menu redirect

## Summary
Fixes two critical production issues:

1. **API 500 Errors**: `/api/pages/about` and `/api/pages/infoes` were failing with 500 errors because `PagesController` was querying `SiteSetting` without the required `tenantId`. Updated both endpoints to extract `tenantId` from `req.tenant.id` (set by `TenantContextMiddleware`) and include it in database queries.

2. **Menu Routing 404s**: Added redirect from `/menu` to `/user/menu` in middleware to handle user requests for the non-existent `/menu` route.

## Review & Testing Checklist for Human

**Critical items to verify (3):**

- [ ] **Verify TenantContextMiddleware is applied**: Confirm that `/api/pages/*` routes have the tenant middleware that sets `req.tenant.id` from the `X-Tenant-Host` header
- [ ] **Test API endpoints with tenant headers**: Call `/api/pages/about` and `/api/pages/infoes` with proper `X-Tenant-Host` header to ensure they return tenant-specific data (not empty strings)
- [ ] **Verify 500 errors are resolved**: Test in production-like environment to confirm the original 500 errors no longer occur

**Additional verification:**
- [ ] Test `/menu` redirect works and doesn't create redirect loops
- [ ] Confirm existing pages functionality isn't broken

### Notes
- The backend changes use type casting `(req as any)?.tenant?.id` which could break silently if tenant structure changes
- If `tenantId` is missing, endpoints now return empty string instead of 500 error (graceful degradation)
- Passkey legacy options issue was already resolved in PR #18

---
*Link to Devin run: https://app.devin.ai/sessions/ef93846b537444f8958278f9a38604e3*  
*Requested by: @Lebid15*