### PR TITLE
fix: force rebuild to apply comprehensive production fixes

### DIFF
--- a/DEPLOYMENT_TRIGGER.md
+++ b/DEPLOYMENT_TRIGGER.md
@@ -1,0 +1,12 @@
+# Deployment Trigger
+
+This file is used to trigger a new deployment after fixing container cleanup issues.
+
+Deployment triggered at: 2025-08-31 23:03:58 UTC
+Purpose: Deploy API fixes from PR #19 after resolving watan-redis container conflicts
+
+## Force rebuild 2025-09-01 00:14:26 UTC
+Purpose: Force complete Docker rebuild to apply PR #19 fixes for:
+- API pages 500 errors (PagesController tenantId fix)
+- /menu 404 errors (middleware redirect fix)  
+- Passkey 400 errors (authentication requirement clarification)

--- a/backend/src/user/pages.controller.ts
+++ b/backend/src/user/pages.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Req } from '@nestjs/common';
+import { Controller, Get, Req, HttpException, HttpStatus } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { SiteSetting } from '../admin/site-setting.entity';
@@ -11,14 +11,30 @@ export class PagesController {
   @Get('about')  
   async about(@Req() req: Request) { 
     const tenantId = (req as any)?.tenant?.id;
-    if (!tenantId) return '';
-    return (await this.repo.findOne({ where: { key: 'about', tenantId } }))?.value ?? ''; 
+    if (!tenantId) {
+      throw new HttpException('Tenant not found', HttpStatus.UNAUTHORIZED);
+    }
+    
+    try {
+      const setting = await this.repo.findOne({ where: { key: 'about', tenantId } });
+      return setting?.value ?? '';
+    } catch (error) {
+      throw new HttpException('Failed to fetch about page', HttpStatus.INTERNAL_SERVER_ERROR);
+    }
   }
   
   @Get('infoes') 
   async infoes(@Req() req: Request) { 
     const tenantId = (req as any)?.tenant?.id;
-    if (!tenantId) return '';
-    return (await this.repo.findOne({ where: { key: 'infoes', tenantId } }))?.value ?? ''; 
+    if (!tenantId) {
+      throw new HttpException('Tenant not found', HttpStatus.UNAUTHORIZED);
+    }
+    
+    try {
+      const setting = await this.repo.findOne({ where: { key: 'infoes', tenantId } });
+      return setting?.value ?? '';
+    } catch (error) {
+      throw new HttpException('Failed to fetch infoes page', HttpStatus.INTERNAL_SERVER_ERROR);
+    }
   }
 }

--- a/frontend/src/hooks/usePasskeys.ts
+++ b/frontend/src/hooks/usePasskeys.ts
@@ -19,7 +19,11 @@ export function usePasskeys() {
       if (verifyRes.status >= 300) throw new Error((verifyRes.data as any)?.message || 'فشل التحقق');
       return verifyRes.data;
     } catch (e: any) {
-      setError(e?.message || 'خطأ في إنشاء Passkey');
+      if (e?.response?.status === 401) {
+        setError('يجب تسجيل الدخول أولاً لإنشاء Passkey');
+      } else {
+        setError(e?.message || 'خطأ في إنشاء Passkey');
+      }
       throw e;
     } finally { setLoading(false); }
   }, []);


### PR DESCRIPTION
# fix: force rebuild to apply comprehensive production fixes

## Summary
This PR addresses persistent production issues where API pages return 500 errors and `/menu` returns 404 errors, despite previous fixes being merged. The core issue appears to be that Docker caching prevented the actual deployment of code changes from PR #19.

**Key Changes:**
- **Enhanced PagesController**: Added proper error handling with HTTP 401 responses when `tenantId` is missing, replacing silent empty string returns
- **Improved Passkey Error Messaging**: Added specific error message for 401 authentication failures
- **Deployment Trigger**: Added deployment trigger file to force Docker rebuild without cache

**⚠️ Breaking Change**: API endpoints `/api/pages/about` and `/api/pages/infoes` now return HTTP 401 instead of empty strings when tenant context is missing.

## Review & Testing Checklist for Human

**Critical (must verify):**
- [ ] **Test API endpoints directly**: Verify `/api/pages/about` and `/api/pages/infoes` return 401 errors (not 500) when called without proper tenant context
- [ ] **Monitor deployment logs**: Ensure Docker actually rebuilds images without using cache during deployment
- [ ] **Frontend compatibility**: Confirm frontend can handle 401 HTTP responses from pages API (previously expected empty strings)
- [ ] **Production verification**: After deployment, test in browser that the original 500 errors and 404 menu redirects are resolved

**Important:**
- [ ] **Tenant middleware verification**: Confirm that `req.tenant.id` is properly set by the tenant context middleware
- [ ] **Database connectivity**: Verify that database queries work correctly in production environment

### Notes
- This PR is primarily a deployment workaround due to Docker caching issues preventing previous fixes from being applied
- The actual code fixes were implemented in PR #19 but never deployed to production
- The `/menu` redirect fix exists in `frontend/src/middleware.ts` from previous work but wasn't included in this diff since it's already in the codebase
- Monitor GitHub Actions deployment closely to ensure the `--no-cache` flag actually triggers a complete rebuild

---
*Link to Devin run: https://app.devin.ai/sessions/ef93846b537444f8958278f9a38604e3*  
*Requested by: @Lebid15*