### PR TITLE
fix: add /menu page to resolve 404 RSC prefetch error

### DIFF
--- a/frontend/src/app/menu/page.tsx
+++ b/frontend/src/app/menu/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function MenuPage() {
+  redirect('/user/menu');
+}


### PR DESCRIPTION
# fix: add /menu page to resolve 404 RSC prefetch error

## Summary
Adds a simple `/menu` page component that redirects to `/user/menu` to resolve React Server Component prefetch 404 errors observed in browser console. 

The issue was that Next.js was trying to prefetch `/menu?_rsc=...` but no page file existed at that route, causing console errors even though the middleware redirect was working correctly for navigation.

## Review & Testing Checklist for Human
**Risk Level: 🟢 Low** - 1 critical item to verify:

- [ ] **Test `/menu` navigation**: Navigate directly to `/menu` in browser and verify it redirects to `/user/menu` without redirect loops or console errors

### Notes
- This is a minimal fix targeting the specific RSC prefetch 404 issue without changing existing middleware logic
- The redirect destination `/user/menu` matches what the middleware was already redirecting to
- Console error pattern: `Failed to load resource: the server responded with a status of 404 () for /menu?_rsc=...`

*Link to Devin run: https://app.devin.ai/sessions/ef93846b537444f8958278f9a38604e3*  
*Requested by: @Lebid15*