### PR TITLE
fix(passkeys): align code with DB change (user_id)

### DIFF
--- a/backend/src/auth/passkeys/passkey-credential.entity.ts
+++ b/backend/src/auth/passkeys/passkey-credential.entity.ts
@@ -7,7 +7,7 @@ import { User } from '../../user/user.entity';
 export class PasskeyCredential {
   @PrimaryGeneratedColumn('uuid') id: string;
 
-  @Column({ type: 'uuid' }) userId: string;
+  @Column({ name: 'user_id', type: 'uuid' }) userId: string;
 
   @ManyToOne(() => User, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'user_id' })


### PR DESCRIPTION
**TL;DR**
مواءمة الكود مع تغيير قاعدة البيانات: استخدام العمود `user_id` بدل `"userId"` في كيان مفاتيح المرور.

**التغييرات**
- تحديث الـ entity: 
  `@Column({ name: 'user_id', type: 'uuid' }) userId: string;`
- لا تغييرات على الـ API contract (الخاصية تبقى `userId` في الكود، تُخزَّن في `user_id`).

**خلفية**
- في قاعدة البيانات: تم حذف العمود `"userId"`، إضافة/فرض `user_id UUID NOT NULL`، وFK إلى `users(id)` مع `ON DELETE CASCADE`.

**الاختبارات/التحقق**
- يمرّ build backend بدون أخطاء TypeORM.
- إنشاء/قراءة/حذف passkey تعمل لمستخدم حقيقي.
- لا توجد استعلامات SQL خام تستخدم `"userId"` بعد الآن.

**ملاحظات النشر**
- لا توجد migration إضافية مطلوبة؛ تغييرات DB مطبقة بالفعل.
