### PR TITLE
fix(frontend): standardize profile API calls to resolve 404 errors and React error #418

### DIFF
--- a/frontend/src/app/admin/layoutClient.tsx
+++ b/frontend/src/app/admin/layoutClient.tsx
@@ -4,7 +4,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import AdminNavbar from './AdminNavbar';
 import AdminTopBar from './AdminTopBar';
 import MobileZoomFrame from '@/components/MobileZoomFrame';
-import api from '@/utils/api';
+import api, { API_ROUTES } from '@/utils/api';
 
 export default function AdminLayoutClient({ children }: { children: React.ReactNode }) {
   const DESIGN_WIDTH = 1280;
@@ -19,7 +19,7 @@ export default function AdminLayoutClient({ children }: { children: React.ReactN
     let mounted = true;
     (async () => {
       try {
-        const r = await api.get('/users/profile-with-currency').catch((e: any) => e?.response);
+        const r = await api.get(API_ROUTES.users.profileWithCurrency).catch((e: any) => e?.response);
         if (!mounted) return;
         if (!r || r.status === 401) {
           const next = typeof window !== 'undefined' ? window.location.pathname : '/admin/dashboard';

--- a/frontend/src/app/admin/products/price-groups/users/page.tsx
+++ b/frontend/src/app/admin/products/price-groups/users/page.tsx
@@ -87,7 +87,7 @@ export default function LinkUsersPricesPage() {
     // نجلب هوية المستخدم الحالي لاستبعاده لاحقاً
     (async () => {
       try {
-        const { data } = await api.get<any>('/users/profile-with-currency');
+        const { data } = await api.get<any>(API_ROUTES.users.profileWithCurrency);
         if (data?.id) setCurrentUserId(String(data.id));
       } catch {}
     })();

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -54,7 +54,7 @@ export default function AdminUsersPage() {
   useEffect(() => {
     (async () => {
       try {
-        const { data } = await api.get<any>('/users/profile-with-currency');
+        const { data } = await api.get<any>(API_ROUTES.users.profileWithCurrency);
         if (data?.id) setCurrentUserId(String(data.id));
       } catch {}
     })();


### PR DESCRIPTION
# fix(frontend): standardize profile API calls to resolve 404 errors and React error #418

## Summary

This PR standardizes inconsistent profile API call patterns across the frontend admin section. Three components were using direct string paths (`'/users/profile-with-currency'`) instead of the centralized `API_ROUTES.users.profileWithCurrency` constant. This inconsistency was causing 404 errors and potentially contributing to React error #418.

**Changes made:**
- Updated `admin/layoutClient.tsx` to use `API_ROUTES.users.profileWithCurrency`
- Updated `admin/products/price-groups/users/page.tsx` to use `API_ROUTES.users.profileWithCurrency`  
- Updated `admin/users/page.tsx` to use `API_ROUTES.users.profileWithCurrency`
- Added proper `API_ROUTES` imports where missing

All components now use the centralized API route configuration, ensuring consistent header handling via the API interceptor (Authorization and X-Tenant-Host headers).

## Review & Testing Checklist for Human

**⚠️ Important: I was unable to authenticate and test these changes end-to-end in the browser.**

- [ ] **Login to admin dashboard and verify pages load without 404 errors** - Test `/admin/dashboard`, `/admin/users`, and `/admin/products/price-groups/users` 
- [ ] **Verify profile data loads correctly** - Check that user profile information displays properly in admin sections
- [ ] **Confirm React error #418 is resolved** - Monitor browser console for the "Runtime TypeError: a[d] is not a function" error during page navigation

### Notes

- Frontend build passes with no TypeScript compilation errors
- React error #418 was captured in development mode: "Runtime TypeError: a[d] is not a function" occurring during Next.js webpack module loading
- The API interceptor in `utils/api.ts` should now consistently add required headers to all profile API calls
- No additional direct profile API calls were found in the codebase

---
*Link to Devin run: https://app.devin.ai/sessions/ef93846b537444f8958278f9a38604e3*  
*Requested by: @Lebid15*