### PR TITLE
Implement internal tenant order routing system

### DIFF
--- a/djangoo/apps/orders/urls.py
+++ b/djangoo/apps/orders/urls.py
@@ -9,6 +9,7 @@ from .views import (
     AdminOrderSyncExternalView,
     AdminOrderRefreshStatusView,
     AdminOrderAuditLogView,
+    InternalDispatchView,
 )
 
 urlpatterns = [
@@ -18,6 +19,8 @@ urlpatterns = [
     path('orders/', OrdersCreateView.as_view(), name='orders-create-slash'),
     path('orders/<uuid:id>', MyOrderDetailsView.as_view(), name='orders-details'),
     path('orders/<uuid:id>/', MyOrderDetailsView.as_view(), name='orders-details-slash'),
+    path('orders/internal/dispatch', InternalDispatchView.as_view(), name='orders-internal-dispatch'),
+    path('orders/internal/dispatch/', InternalDispatchView.as_view(), name='orders-internal-dispatch-slash'),
 ]
 
 # Admin routes are included at root include with prefix 'admin/' in config urls

--- a/djangoo/apps/providers/migrations/0005_add_internal_tenant_fields.py
+++ b/djangoo/apps/providers/migrations/0005_add_internal_tenant_fields.py
@@ -1,0 +1,32 @@
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('providers', '0004_enhance_routing_system'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='packagerouting',
+            name='internal_tenant_id',
+            field=models.UUIDField(
+                blank=True,
+                db_column='internalTenantId',
+                help_text='معرف المستأجر الداخلي للتوجيه بين المستأجرين',
+                null=True
+            ),
+        ),
+        migrations.AddField(
+            model_name='packagerouting',
+            name='internal_api_user_id',
+            field=models.UUIDField(
+                blank=True,
+                db_column='internalApiUserId',
+                help_text='معرف مستخدم API في المستأجر الداخلي (مثل diana)',
+                null=True
+            ),
+        ),
+    ]

--- a/djangoo/apps/providers/models.py
+++ b/djangoo/apps/providers/models.py
@@ -91,6 +91,7 @@ class PackageRouting(models.Model):
         choices=[
             ('manual', 'يدوي'),
             ('external', 'خارجي'),
+            ('internal', 'مستأجر داخلي'),
             ('internal_codes', 'أكواد داخلية'),
             ('codes', 'أكواد'),  # للتوافق مع الإصدارات القديمة
         ],
@@ -120,6 +121,21 @@ class PackageRouting(models.Model):
         blank=True,
         db_column='codeGroupId',
         help_text='معرف مجموعة الأكواد للمزود الداخلي'
+    )
+    
+    # إعدادات المستأجر الداخلي
+    internal_tenant_id = models.UUIDField(
+        null=True,
+        blank=True,
+        db_column='internalTenantId',
+        help_text='معرف المستأجر الداخلي للتوجيه بين المستأجرين'
+    )
+    
+    internal_api_user_id = models.UUIDField(
+        null=True,
+        blank=True,
+        db_column='internalApiUserId',
+        help_text='معرف مستخدم API في المستأجر الداخلي (مثل diana)'
     )
     
     # حقول إضافية للتحسين

--- a/djangoo/config/settings.py
+++ b/djangoo/config/settings.py
@@ -43,8 +43,8 @@ def _env_flag(name: str, default: str = "0") -> bool:
 
 # Feature flags (Phase 0 scaffolding) – default to False/disabled
 FF_CHAIN_STATUS_PROPAGATION = _env_flag("FF_CHAIN_STATUS_PROPAGATION", "1")  # ✅ Enabled for chain wallet updates
-FF_USD_COST_ENFORCEMENT = _env_flag("FF_USD_COST_ENFORCEMENT", "0")
-FF_AUTO_FALLBACK_ROUTING = _env_flag("FF_AUTO_FALLBACK_ROUTING", "0")
+FF_USD_COST_ENFORCEMENT = _env_flag("FF_USD_COST_ENFORCEMENT", "1")  # ✅ Enabled for cost resolution from providers
+FF_AUTO_FALLBACK_ROUTING = _env_flag("FF_AUTO_FALLBACK_ROUTING", "1")  # ✅ Enabled for automatic fallback to Manual on failures
 FF_ADMIN_REROUTE_UI = _env_flag("FF_ADMIN_REROUTE_UI", "0")
 
 INSTALLED_APPS = [


### PR DESCRIPTION
# Implement internal tenant order routing system

## Summary
Implements multi-tenant order routing that allows orders to be automatically dispatched from one tenant (alsham) to another tenant (shamtech) within the same Watan platform. This is part of the larger order routing specification that includes Manual, Auto, and Fallback routing modes.

**Key Changes:**
- Added `InternalDispatchView` API endpoint (`/api-dj/orders/internal/dispatch`) for receiving orders from other tenants with Bearer token authentication
- Extended `PackageRouting` model with `internal_tenant_id` and `internal_api_user_id` fields for configuring internal routing
- Implemented internal provider routing logic in `try_auto_dispatch` function (services.py:2756-3042) with comprehensive error handling
- Added cost resolution from internal tenant pricing (diana's price group in shamtech) instead of local price groups
- Enabled feature flags: `FF_USD_COST_ENFORCEMENT` and `FF_AUTO_FALLBACK_ROUTING`
- Automatic fallback to Manual mode on all dispatch failures
- Created database migration for new PackageRouting fields

**Flow:**
1. User creates order in alsham → Order enters pending state
2. If routing mode is Auto and provider_type is 'internal':
   - Resolves package mapping (alsham package → shamtech package)
   - Retrieves API token for diana user in shamtech
   - POSTs to shamtech's internal dispatch endpoint with Bearer auth
   - Shamtech creates order, deducts balance from diana user
   - Cost is calculated from shamtech's PackagePrice for diana's price_group
3. On any failure → Order falls back to Manual mode (pending status)

## Review & Testing Checklist for Human

⚠️ **Critical: This PR cannot be fully tested without a running environment with database and multiple configured tenants**

- [ ] **End-to-end flow test**: Create an order in alsham tenant with Auto routing configured to shamtech. Verify order appears in shamtech with correct details and cost is from shamtech's pricing (not alsham's local price groups)
- [ ] **Authentication test**: Verify the internal dispatch endpoint properly authenticates with Bearer token from diana API user and rejects invalid tokens
- [ ] **Fallback scenarios**: Test that orders properly fall back to Manual mode when: (a) no package mapping exists, (b) no API token configured, (c) insufficient balance in shamtech, (d) shamtech endpoint unreachable
- [ ] **Balance deduction**: Verify balance is correctly deducted from diana user in shamtech tenant when order is created
- [ ] **Migration**: Run migration `0005_add_internal_tenant_fields` on staging database and verify no errors
- [ ] **Existing orders**: Verify existing orders with Auto routing to external providers still work correctly after feature flag changes

### Recommended Test Plan
1. Set up two tenants: alsham (sender) and shamtech (receiver)
2. Create diana API user in shamtech, generate token
3. Add Integration in alsham with provider='internal', api_token=diana_token
4. Configure PackageRouting in alsham with mode='auto', provider_type='internal', internal_tenant_id=shamtech.id, internal_api_user_id=diana.id
5. Set up PackageMapping between alsham package and shamtech package
6. Create test order in alsham
7. Verify order created in shamtech and cost calculated from diana's price group

### Notes
- Session URL: https://app.devin.ai/sessions/3b6e618dcfa443a5b1c8eb9fa0ee3ff9
- Requested by: io (alayatl.tr@gmail.com) / @Lebid15
- The internal dispatch URL is constructed as `/api-dj/orders/internal/dispatch` - verify this matches your Django routing configuration
- Feature flags `FF_USD_COST_ENFORCEMENT` and `FF_AUTO_FALLBACK_ROUTING` are now enabled by default (changed from "0" to "1")
- Cost calculation assumes diana user has a price_group_id in shamtech tenant - if not, it falls back to default package price
- The chain tracking fields (root_order_id, chain_path) are set to link orders across tenants for audit trail